### PR TITLE
Issue #9 Unable to read older data from Redis post upgrade to OSS streambase

### DIFF
--- a/src/main/java/org/eclipse/ecsp/cache/redis/RedisPackageMappingCustomCodec.java
+++ b/src/main/java/org/eclipse/ecsp/cache/redis/RedisPackageMappingCustomCodec.java
@@ -1,0 +1,170 @@
+package org.eclipse.ecsp.cache.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufOutputStream;
+import org.apache.commons.io.IOUtils;
+import org.eclipse.ecsp.entities.dma.RetryRecord;
+import org.eclipse.ecsp.entities.dma.RetryRecordIds;
+import org.eclipse.ecsp.entities.dma.VehicleIdDeviceIdMapping;
+import org.eclipse.ecsp.utils.logger.IgniteLogger;
+import org.eclipse.ecsp.utils.logger.IgniteLoggerFactory;
+import org.redisson.client.codec.Codec;
+import org.redisson.client.handler.State;
+import org.redisson.client.protocol.Decoder;
+import org.redisson.client.protocol.Encoder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Custom decoder for Redis that maps old package names to new ones for specific entities.
+ * This is used to ensure compatibility with the new package structure in the ECSP project.
+ *
+ * @author HBadshah
+ */
+public class RedisPackageMappingCustomCodec implements Codec {
+    
+    private static final IgniteLogger LOGGER = IgniteLoggerFactory.getLogger(RedisPackageMappingCustomCodec.class);
+    
+    private ObjectMapper objectMapper;
+
+    private final Encoder encoder = new Encoder() {
+
+        @Override
+        public ByteBuf encode(Object in) throws IOException {
+            LOGGER.info("Encoding object : {} as ByteBuf type in custom RedisPackageMappingCustomCodec.", in);
+            ByteBuf out = ByteBufAllocator.DEFAULT.buffer();
+            try (ByteBufOutputStream os = new ByteBufOutputStream(out)) {
+                byte[] b = objectMapper.writeValueAsBytes(in);
+                os.write(b);
+                return os.buffer();
+            }
+        }
+    };
+
+    /**
+     * Constructor for RedisPackageMappingCustomCodec.
+     *
+     * @param objectMapper the ObjectMapper to use for serialization/deserialization
+     */
+    public RedisPackageMappingCustomCodec(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    private final Decoder<Object> valueDecoder = new Decoder<Object>() {
+
+        @Override
+        public Object decode(ByteBuf buf, State state) {
+            try (InputStream stream = new ByteBufInputStream(buf)) { 
+                StringWriter writer = new StringWriter();
+                IOUtils.copy(stream, writer, StandardCharsets.UTF_8);
+                String value = writer.toString();
+                String className = value.substring(value.indexOf(":") + RedisConstants.TWO.getValue(), 
+                    value.indexOf(",") - 1);
+                LOGGER.info("Fetched data of type: {} from Redis to be decoded.", className);
+            
+                if (className.equals(RedisProperty.OLD_PACKAGE_NAME_ENTITIES + ".dma.VehicleIdDeviceIdMapping")) {
+                    return decodeVehicleIdDeviceIdMapping(value);
+                } else if (className.equals(RedisProperty.OLD_PACKAGE_NAME_ENTITIES + ".dma.RetryRecord")) {
+                    return decodeRetryRecord(value);
+                } else if (className.equals(RedisProperty.OLD_PACKAGE_NAME_ENTITIES + ".dma.RetryRecordIds")) {
+                    return decodeRetryRecordIds(value);
+                }
+            } catch (IOException e) {
+                LOGGER.error("Error decoding value from Redis: {}", e.getMessage(), e);
+            }
+            LOGGER.warn("No matching class found for decoding. Returning null.");
+            return null;
+        }
+        
+        private VehicleIdDeviceIdMapping decodeVehicleIdDeviceIdMapping(String value) throws IOException {
+            LOGGER.info("Decoding VehicleIdDeviceIdMapping object.");
+            value = value.replace(RedisProperty.OLD_PACKAGE_NAME_ENTITIES, RedisProperty.NEW_PACKAGE_NAME_ENTITIES);
+            value = value.replace(RedisProperty.CONCURRECT_HASH_SET_OLD, RedisProperty.CONCURRECT_HASH_SET_NEW);
+            return objectMapper.readValue(value, VehicleIdDeviceIdMapping.class);
+        }
+
+        private RetryRecord decodeRetryRecord(String value) {
+            try {
+                LOGGER.info("Decoding RetryRecord object.");
+                if (value.contains(RedisProperty.OLD_PACKAGE_NAME_ENTITIES)) {
+                    value = value.replace(RedisProperty.OLD_PACKAGE_NAME_ENTITIES, 
+                            RedisProperty.NEW_PACKAGE_NAME_ENTITIES);
+                }
+                if (value.contains(RedisProperty.IGNITE_STRING_KEY_OLD)) {
+                    value = value.replace(RedisProperty.IGNITE_STRING_KEY_OLD, RedisProperty.IGNITE_STRING_KEY_NEW);
+                }
+                return objectMapper.readValue(value, RetryRecord.class);
+            } catch (IOException e) {
+                LOGGER.error("Error decoding RetryRecord: {}", e.getMessage(), e);
+                return null;
+            }
+        }
+        
+        private RetryRecordIds decodeRetryRecordIds(String value) throws IOException {
+            LOGGER.info("Decoding RetryRecordIds object.");
+            value = value.replace(RedisProperty.OLD_PACKAGE_NAME_ENTITIES, RedisProperty.NEW_PACKAGE_NAME_ENTITIES)
+                         .replace(RedisProperty.CONCURRECT_HASH_SET_OLD, RedisProperty.CONCURRECT_HASH_SET_NEW);
+            return objectMapper.readValue(value, RetryRecordIds.class);
+        }
+    };
+    
+    private final Decoder<Object> keyDecoder = new Decoder<Object>() {
+
+        @Override
+        public Object decode(ByteBuf buf, State state) throws IOException {
+            try (InputStream stream = new ByteBufInputStream(buf)) {
+                StringWriter writer = new StringWriter();
+                IOUtils.copy(stream, writer, StandardCharsets.UTF_8);
+                String value = writer.toString();        
+                LOGGER.debug("Decoding key :{}", value);
+                return objectMapper.readValue(value, String.class);
+            }
+        }
+    };
+
+    @Override
+    public Decoder<Object> getMapValueDecoder() {
+        return valueDecoder;
+    }
+
+    @Override
+    public Encoder getMapValueEncoder() {
+        return encoder;
+    }
+
+    @Override
+    public Decoder<Object> getMapKeyDecoder() {
+        return keyDecoder;
+    }
+
+    @Override
+    public Encoder getMapKeyEncoder() {
+        return encoder;
+    }
+
+    @Override
+    public Decoder<Object> getValueDecoder() {
+        return valueDecoder;
+    }
+
+    @Override
+    public Encoder getValueEncoder() {
+        return encoder;
+    }
+
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return null;
+    }
+
+}

--- a/src/main/java/org/eclipse/ecsp/cache/redis/RedisProperty.java
+++ b/src/main/java/org/eclipse/ecsp/cache/redis/RedisProperty.java
@@ -158,4 +158,16 @@ public abstract class RedisProperty {
     
     /** The Constant REDIS_CHECK_SLOTS_COVERAGE. */
     public static final String REDIS_CHECK_SLOTS_COVERAGE = "redis.check.slots.coverage";
+    
+    public static final String OLD_PACKAGE_NAME_ENTITIES = "com.harman.ignite.entities";
+    
+    public static final String NEW_PACKAGE_NAME_ENTITIES = "org.eclipse.ecsp.entities";
+    
+    public static final String IGNITE_STRING_KEY_OLD = "com.harman.ignite.key.IgniteStringKey";
+    
+    public static final String IGNITE_STRING_KEY_NEW = "org.eclipse.ecsp.key.IgniteStringKey";
+    
+    public static final String CONCURRECT_HASH_SET_OLD = "com.harman.ignite.utils.ConcurrentHashSet";
+    
+    public static final String CONCURRECT_HASH_SET_NEW = "org.eclipse.ecsp.utils.ConcurrentHashSet";
 }


### PR DESCRIPTION
Please refer to our [contributing docs](./CONTRIBUTING.md) for any questions on submitting a pull request.
Issues are required for both bug fixes and features.

Resolves #9 

----
### Describe behaviour before the change
In OSS streambase the package names have been changed, and the data that lies in Redis contains the older package names of all the types. When services will be upgraded to newer (OSS) streambase, they won't be able to read the existing or older data from Redis because the types with older package names don't exist anymore in the new streambase embedded in the services.
* 

### Describe behaviour after the change
We wrote a custom decoder for the ObjectMapper so we could intercept the data read from Redis, modify it to replace the older package names with newer package names so that the ObjectMapper is able to map the JSON read from Redis to the Java POJO.
* 

### Pull request checklist
- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] All new and existing tests passed.
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [ ] No

----

