### PR TITLE
WI 754476: Generify Cache-Enabler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.13.2</junit.version>
-        <transformers.version>1.0.0</transformers.version>
+        <ecsp.utils.version>1.1.1</ecsp.utils.version>
         <maven.surefire.version>2.18.1</maven.surefire.version>
         <docker.java.version>3.3.6</docker.java.version>
         <testcontainers.version>1.17.6</testcontainers.version>
@@ -109,6 +109,8 @@
         <jacoco.ut.execution.data.file>${project.build.directory}/coverage-reports/jacoco-ut.exec
         </jacoco.ut.execution.data.file>
         <commons.io.version>2.11.0</commons.io.version>
+        <springframework.boot.version>3.5.4</springframework.boot.version>
+        <jackson.dataformat.version>2.17.1</jackson.dataformat.version>
     </properties>
 
     <pluginRepositories>
@@ -124,8 +126,18 @@
     <dependencies>
         <dependency>
             <groupId>org.eclipse.ecsp</groupId>
-            <artifactId>transformers</artifactId>
-            <version>${transformers.version}</version>
+            <artifactId>utils</artifactId>
+            <version>${ecsp.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <version>${springframework.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>${springframework.boot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
@@ -222,13 +234,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.17.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>${jackson.dataformat.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/eclipse/ecsp/cache/IgniteCache.java
+++ b/src/main/java/org/eclipse/ecsp/cache/IgniteCache.java
@@ -36,15 +36,13 @@
 
 package org.eclipse.ecsp.cache;
 
-import org.eclipse.ecsp.entities.IgniteEntity;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Future;
 
 /**
- * Base contract for cache in Ignite.
+ * Base contract for cache in Platform.
  * Support for optimized implementations that can perform batched updates through its .*Async() methods.
  * Clients of this interface are encouraged to use Async methods to improve throughput.
  * This may not be possible in all cases, for ex if the same value has to be read back immediately from Redis.
@@ -54,7 +52,6 @@ import java.util.concurrent.Future;
  * Operations support 2 data types:
  * <ul>
  * <li>String</li>
- * <li>IgniteEntity</li>
  * </ul>
  *
  * @author ssasidharan
@@ -94,37 +91,37 @@ public interface IgniteCache {
     /**
      * Retrieves an entity based on the provided request.
      *
-     * @param <T> the type of the entity extending IgniteEntity
+     * @param <T> the type of the entity
      * @param getRequest the request containing the parameters for retrieving the entity
      * @return the entity based on the request
      */
-    <T extends IgniteEntity> T getEntity(GetEntityRequest getRequest);
+    <T> T getEntity(GetEntityRequest getRequest);
 
     /**
      * Retrieves an entity associated with the given key.
      *
-     * @param <T> the type of the entity extending IgniteEntity
+     * @param <T> the type of the entity
      * @param key the key to retrieve the entity for
      * @return the entity associated with the key
      */
-    <T extends IgniteEntity> T getEntity(String key);
+    <T> T getEntity(String key);
 
     /**
      * Stores an entity based on the provided request.
      *
-     * @param <T> the type of the entity extending IgniteEntity
+     * @param <T> the type of the entity
      * @param putRequest the request containing the parameters for storing the entity
      */
-    <T extends IgniteEntity> void putEntity(PutEntityRequest<T> putRequest);
+    <T> void putEntity(PutEntityRequest<T> putRequest);
 
     /**
      * Adds the put entity mutation operation to a batch and completes the future when the batch is committed.
      *
      * @param putRequest the put entity request
-     * @param <T> the type of the entity extending IgniteEntity
+     * @param <T> the type of the entity
      * @return future that returns the mutationId from the original request
      */
-    <T extends IgniteEntity> Future<String> putEntityAsync(PutEntityRequest<T> putRequest);
+    <T> Future<String> putEntityAsync(PutEntityRequest<T> putRequest);
 
     /**
      * Adds a string to a scored sorted set based on the provided request.
@@ -152,38 +149,38 @@ public interface IgniteCache {
     /**
      * Adds an entity to a scored sorted set based on the provided request.
      *
-     * @param <T> the type of the entity extending IgniteEntity
+     * @param <T> the type of the entity
      * @param request the request containing the parameters for adding the entity to the scored sorted set
      */
-    <T extends IgniteEntity> void addEntityToScoredSortedSet(AddScoredEntityRequest<T> request);
+    <T> void addEntityToScoredSortedSet(AddScoredEntityRequest<T> request);
 
     /**
      * Adds the scored set entity append mutation to a batch and completes the future when the batch is committed.
      *
-     * @param <T> the type of the entity extending IgniteEntity
+     * @param <T> the type of the entity
      * @param request the add scored entity request
      * @return future that returns the mutationId from the original request
      */
-    <T extends IgniteEntity> Future<String> addEntityToScoredSortedSetAsync(AddScoredEntityRequest<T> request);
+    <T> Future<String> addEntityToScoredSortedSetAsync(AddScoredEntityRequest<T> request);
 
     /**
      * Retrieves a list of entities from a scored sorted set based on the provided request.
      *
-     * @param <T> the type of the entity extending IgniteEntity
+     * @param <T> the type of the entity
      * @param request the request containing the parameters for retrieving the entities
      * @return the list of entities from the scored sorted set
      */
-    <T extends IgniteEntity> List<T> getEntitiesFromScoredSortedSet(GetScoredEntitiesRequest request);
+    <T> List<T> getEntitiesFromScoredSortedSet(GetScoredEntitiesRequest request);
 
     /**
      * Retrieves a map of key-value pairs for entities matching the given key regex.
      *
-     * @param <T> the type of the entity extending IgniteEntity
+     * @param <T> the type of the entity
      * @param keyRegex the regex pattern to match keys
      * @param namespaceEnabled optional flag to enable namespace
      * @return the map of key-value pairs for entities matching the key regex
      */
-    <T extends IgniteEntity> Map<String, T> getKeyValuePairsForRegex(String keyRegex,
+    <T> Map<String, T> getKeyValuePairsForRegex(String keyRegex,
             Optional<Boolean> namespaceEnabled);
 
     /**
@@ -211,19 +208,19 @@ public interface IgniteCache {
     /**
      * Stores a map of entities based on the provided request.
      *
-     * @param <T> the type of the entity extending IgniteEntity
+     * @param <T> the type of the entity
      * @param request the request containing the parameters for storing the map of entities
      */
-    <T extends IgniteEntity> void putMapOfEntities(PutMapOfEntitiesRequest<T> request);
+    <T> void putMapOfEntities(PutMapOfEntitiesRequest<T> request);
 
     /**
      * Retrieves a map of entities based on the provided request.
      *
-     * @param <T> the type of the entity extending IgniteEntity
+     * @param <T> the type of the entity
      * @param request the request containing the parameters for retrieving the map of entities
      * @return the map of entities based on the request
      */
-    <T extends IgniteEntity> Map<String, T> getMapOfEntities(GetMapOfEntitiesRequest request);
+    <T> Map<String, T> getMapOfEntities(GetMapOfEntitiesRequest request);
 
     /**
      * Deletes a map of entities based on the provided request.

--- a/src/main/java/org/eclipse/ecsp/cache/config/JacksonConfigType.java
+++ b/src/main/java/org/eclipse/ecsp/cache/config/JacksonConfigType.java
@@ -1,0 +1,16 @@
+package org.eclipse.ecsp.cache.config;
+
+/**
+ * Enum to define the serializer and deserializer enum to be used with jackson.
+ */
+public enum JacksonConfigType {
+    
+    /** The serializer. */
+    SERIALIZER,
+    
+    /** The deserializer. */
+    DESERIALIZER,
+    
+    /** The subtype. */
+    SUBTYPE
+}

--- a/src/main/java/org/eclipse/ecsp/cache/config/JacksonMapperConfig.java
+++ b/src/main/java/org/eclipse/ecsp/cache/config/JacksonMapperConfig.java
@@ -1,0 +1,356 @@
+package org.eclipse.ecsp.cache.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.ecsp.utils.logger.IgniteLogger;
+import org.eclipse.ecsp.utils.logger.IgniteLoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ResolvableType;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Properties;
+
+/**
+ * Customised jackson mapper initialization sot that it can be used by APIs as well as stream processors.
+ * 
+ *<p>
+ * Many times we would like to add custom serde for our POJO, we can use this jackson mapper configuration to handle.
+ *</p>
+ */
+@Configuration
+public class JacksonMapperConfig {
+
+    /** The logger. */
+    IgniteLogger logger = IgniteLoggerFactory.getLogger(JacksonMapperConfig.class);
+
+    /** The Constant CUSTOM_SERIALIZERS. */
+    private static final String CUSTOM_SERIALIZERS = "custom.serializers";
+    
+    /** The Constant CUSTOM_DESERIALIZERS. */
+    private static final String CUSTOM_DESERIALIZERS = "custom.deserializers";
+    
+    /** The Constant CUSTOM_SUBTYPES. */
+    private static final String CUSTOM_SUBTYPES = "custom.subtypes";
+    
+    /** The empty String. */
+    public static final String EMPTY_STRING = "";
+    
+    /** The Constant TWO. */
+    public static final int TWO = 2;
+
+    /** The comma. */
+    private final String comma = ",";
+    
+    /** The colon. */
+    private final String colon = ":";
+    
+    /** 
+     * comma separated list of "className:Serializers" to be added to the
+     * Jackson's ObjectMapper. Class and it's corresponding serializers has to
+     * be separated by colon.
+    */
+    @Value("${" + CUSTOM_SERIALIZERS + ":}")
+    private String customSerializers;
+
+    /** 
+     * comma separated list of "className:Deserializers" to be added to the
+     * Jackson's ObjectMapper. Class and it's corresponding deserializers has to
+     * be separated by colon.
+     */
+    @Value("${" + CUSTOM_DESERIALIZERS + ":}")
+    private String customDeserializers;
+
+    /** Sometimes you might want to add named subtypes. */
+    @Value("${" + CUSTOM_SUBTYPES + ":}")
+    private String customSubtypes;
+
+    /**
+     * Instantiates a new jackson mapper config.
+     */
+    @Autowired
+    public JacksonMapperConfig() {
+
+    }
+
+    /**
+     * Method for JacksonMapper Configuration.
+     *
+     * @param props the props
+     */
+    public JacksonMapperConfig(Properties props) {
+        if (null != props.get(CUSTOM_SERIALIZERS)) {
+            this.customSerializers = props.getProperty(CUSTOM_SERIALIZERS);
+        }
+        if (null != props.get(CUSTOM_DESERIALIZERS)) {
+            this.customDeserializers = props.getProperty(CUSTOM_DESERIALIZERS);
+        }
+        if (null != props.get(CUSTOM_SUBTYPES)) {
+            this.customSubtypes = props.getProperty(CUSTOM_SUBTYPES);
+        }
+        logger.info("Values loaded from properties for JacksonMapperConfig - "
+                + "customSerializers :{}, customDeserializers: {},customSubtypes: {}",
+                customSerializers, customDeserializers, customSubtypes);
+    }
+
+    /**
+     * Creates and applies relevant settings on the ObjectMapper instance.
+     * For example: Setting serializers, deserializers, etc. in the ObjectMapper instance.
+     *
+     * @return ObjectMapper : ObjectMapper
+     */
+    @Bean("jsonMapper")
+    public ObjectMapper jsonObjectMapper() {
+        ArrayList<Module> modules = new ArrayList<>();
+        SimpleModule jacksonsModule = new SimpleModule();
+        ObjectMapper objectMapper = null;
+
+        try {
+            if (!StringUtils.isEmpty(customSerializers)) {
+                logger.info("Adding custom serializer:{}", customSerializers);
+                add(jacksonsModule, customSerializers, JacksonConfigType.SERIALIZER);
+            }
+
+            String deserializersList = EMPTY_STRING;
+
+            if (!StringUtils.isEmpty(customDeserializers)) {
+                deserializersList = customDeserializers;
+            }
+
+            logger.info("Adding  deserializer list:{}", deserializersList);
+            add(jacksonsModule, deserializersList, JacksonConfigType.DESERIALIZER);
+
+            // adding named subtypes if any
+            if (!StringUtils.isEmpty(customSubtypes)) {
+                logger.info("Adding custom named subtypes:{}", customSubtypes);
+                add(jacksonsModule, customSubtypes, JacksonConfigType.SUBTYPE);
+            }
+
+            modules.add(jacksonsModule);
+
+            objectMapper = new ObjectMapper();
+            objectMapper.registerModules(modules);
+
+            objectMapper.setSerializationInclusion(Include.NON_NULL);
+            objectMapper.setFilterProvider(new SimpleFilterProvider().setFailOnUnknownId(false));
+            objectMapper.setSerializationInclusion(Include.NON_EMPTY);
+            objectMapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
+            objectMapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        } catch (Exception e) {
+            logger.error("Exception while creating object mapper", e);
+            throw new IllegalStateException("Exception while creating object mapper");
+        }
+        return objectMapper;
+
+    }
+
+    /**
+     * Helper method to add the serializer and deserializer parameter to the
+     * jackson module.
+     *
+     * @param jacksonModule the SimpleModule instance.
+     * @param serdes SerDe class for specific types
+     * @param type the JacksonConfigType
+     * 
+     * @throws InstantiationException the instantiation exception
+     * @throws IllegalAccessException the illegal access exception
+     * @throws ClassNotFoundException the class not found exception
+     * @throws InvocationTargetException the invocation target exception
+     * @throws NoSuchMethodException the no such method exception
+     */
+    private void add(SimpleModule jacksonModule, String serdes, JacksonConfigType type)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException, InvocationTargetException,
+            NoSuchMethodException {
+        if (StringUtils.isNotEmpty(serdes)) {
+            String[] serdeList = serdes.split(comma);
+            logger.info("Processing:{} for serde type:{}", serdes, type);
+            for (String entry : serdeList) {
+                processEachSerde(jacksonModule, type, entry);
+            }
+        }
+    }
+
+    /**
+     * Process each serde. This is the helper method to add each SerDe to ObjectMapper instance.
+     *
+     * @param jacksonModule the SimpleModule instance
+     * @param type JacksonConfigType 
+     * @param serde the serde
+     * @throws ClassNotFoundException the class not found exception
+     * @throws InstantiationException the instantiation exception
+     * @throws IllegalAccessException the illegal access exception
+     * @throws InvocationTargetException the invocation target exception
+     * @throws NoSuchMethodException the no such method exception
+     */
+    private void processEachSerde(SimpleModule jacksonModule, JacksonConfigType type, String serde)
+            throws ClassNotFoundException, InstantiationException, IllegalAccessException, InvocationTargetException,
+            NoSuchMethodException {
+        // entry can be null while running test cases.
+        if (!StringUtils.isEmpty(serde) && !StringUtils.isEmpty(serde.trim())) {
+            String[] serdesArray = serde.split(colon);
+            if (serdesArray.length == TWO) {
+                String className = serdesArray[0];
+                if (StringUtils.isEmpty(className)) {
+                    throw new IllegalStateException("Class name cannot be null or empty. Received entry as:" + serde);
+                }
+
+                addToJacksonModuleWithType(type, serdesArray, jacksonModule);
+            } else {
+                throw new IllegalStateException("Expecting key value pair separated by colon but received:" + serde);
+            }
+        }
+    }
+
+    /**
+     * Adds the to jackson module with type. 
+     * This is the helper method to add each SerDe to ObjectMapper instance.
+     *
+     * @param type the JacksonConfigType
+     * @param serdesArray the serdes array
+     * @param jacksonModule the SimpleModule
+     * @throws ClassNotFoundException the class not found exception
+     * @throws InstantiationException the instantiation exception
+     * @throws IllegalAccessException the illegal access exception
+     * @throws InvocationTargetException the invocation target exception
+     * @throws NoSuchMethodException the no such method exception
+     */
+    private void addToJacksonModuleWithType(JacksonConfigType type, String[] serdesArray, SimpleModule jacksonModule)
+            throws ClassNotFoundException, InstantiationException, IllegalAccessException, InvocationTargetException,
+            NoSuchMethodException {
+        String className = serdesArray[0];
+        String serdeName = serdesArray[1];
+        switch (type) {
+            case SERIALIZER:
+                logger.info("Adding {} class and its serializer class:{} to jackson simple module",
+                        className, serdeName);
+                addSerializer(serdeName, jacksonModule);
+                break;
+
+            case DESERIALIZER:
+                logger.info("Adding {} class and its deserializer class:{} to jackson simple module",
+                        className, serdeName);
+                addDeSerializer(serdeName, jacksonModule);
+                break;
+
+            case SUBTYPE:
+                logger.info("Registering the named subtype with typename:{} and classname:{}",
+                        serdeName, className);
+                jacksonModule.registerSubtypes(new NamedType(Class.forName(className), serdeName));
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Adds the serializer. This is the helper method to add each serializer to ObjectMapper instance.
+     *
+     * @param <T> the generic type
+     * @param serdeName the serde name
+     * @param jacksonModule the jackson module
+     * @throws ClassNotFoundException the class not found exception
+     * @throws InstantiationException the instantiation exception
+     * @throws IllegalAccessException the illegal access exception
+     * @throws NoSuchMethodException the no such method exception
+     * @throws InvocationTargetException the invocation target exception
+     */
+    private <T> void addSerializer(String serdeName, SimpleModule jacksonModule)
+            throws ClassNotFoundException, InstantiationException, IllegalAccessException, NoSuchMethodException,
+            InvocationTargetException {
+        JsonSerializer<T> serializer = (JsonSerializer<T>) Class.forName(serdeName).getClassLoader()
+                .loadClass(serdeName).getDeclaredConstructor().newInstance();
+
+        ResolvableType resolvableType = ResolvableType.forClass(JsonSerializer.class, serializer.getClass());
+        jacksonModule.addSerializer((Class<T>) resolvableType.resolveGeneric(), serializer);
+    }
+
+    /**
+     * Adds the de serializer. This is the helper method to add each deserializer to ObjectMapper instance.
+     *
+     * @param <T> the generic type
+     * @param serdeName the serde name
+     * @param jacksonModule the jackson module
+     * @throws ClassNotFoundException the class not found exception
+     * @throws InstantiationException the instantiation exception
+     * @throws IllegalAccessException the illegal access exception
+     * @throws NoSuchMethodException the no such method exception
+     * @throws InvocationTargetException the invocation target exception
+     */
+    private <T> void addDeSerializer(String serdeName, SimpleModule jacksonModule)
+            throws ClassNotFoundException, InstantiationException, IllegalAccessException, NoSuchMethodException,
+            InvocationTargetException {
+        JsonDeserializer<T> deserializer = (JsonDeserializer<T>) Class.forName(serdeName).getClassLoader()
+                .loadClass(serdeName).getDeclaredConstructor().newInstance();
+        ResolvableType resolvableType = ResolvableType.forClass(JsonDeserializer.class, deserializer.getClass());
+        jacksonModule.addDeserializer((Class<T>) resolvableType.resolveGeneric(), deserializer);
+    }
+
+    /**
+     * Gets the custom serializers.
+     *
+     * @return the custom serializers
+     */
+    String getCustomSerializers() {
+        return customSerializers;
+    }
+
+    /**
+     * Sets the custom serializers.
+     *
+     * @param customSerializers the new custom serializers
+     */
+    void setCustomSerializers(String customSerializers) {
+        this.customSerializers = customSerializers;
+    }
+
+    /**
+     * Gets the custom deserializers.
+     *
+     * @return the custom deserializers
+     */
+    String getCustomDeserializers() {
+        return customDeserializers;
+    }
+
+    /**
+     * Sets the custom deserializers.
+     *
+     * @param customDeserializers the new custom deserializers
+     */
+    void setCustomDeserializers(String customDeserializers) {
+        this.customDeserializers = customDeserializers;
+    }
+
+    /**
+     * Gets the custom subtypes.
+     *
+     * @return the custom subtypes
+     */
+    String getCustomSubtypes() {
+        return customSubtypes;
+    }
+
+    /**
+     * Sets the custom subtypes.
+     *
+     * @param customSubtypes the new custom subtypes
+     */
+    void setCustomSubtypes(String customSubtypes) {
+        this.customSubtypes = customSubtypes;
+    }
+
+}

--- a/src/main/java/org/eclipse/ecsp/cache/redis/IgniteCacheRedisImpl.java
+++ b/src/main/java/org/eclipse/ecsp/cache/redis/IgniteCacheRedisImpl.java
@@ -59,7 +59,6 @@ import org.eclipse.ecsp.cache.exception.FileNotFoundException;
 import org.eclipse.ecsp.cache.exception.IgniteCacheException;
 import org.eclipse.ecsp.cache.exception.JacksonCodecException;
 import org.eclipse.ecsp.cache.exception.RedisBatchProcessingException;
-import org.eclipse.ecsp.entities.IgniteEntity;
 import org.eclipse.ecsp.healthcheck.HealthMonitor;
 import org.eclipse.ecsp.utils.logger.IgniteLogger;
 import org.eclipse.ecsp.utils.logger.IgniteLoggerFactory;
@@ -107,9 +106,12 @@ import static org.eclipse.ecsp.cache.redis.RedisProperty.REDIS_KEY_NAMESPACE_DEL
 /**
  * Implementation of IgniteCache for Redis backend.<br>
  * Supports pipelined batch executions through its .*Async() methods.<br>
- * Clients of this class are encouraged to use Async methods to improve throughput.<br>
- * This may not be possible in all cases, for ex if the same value has to be read back immediately from Redis.<br>
- * But for typical store and forget or store and retrieve slightly later use cases,
+ * Clients of this class are encouraged to use Async methods to improve
+ * throughput.<br>
+ * This may not be possible in all cases, for ex if the same value has to be
+ * read back immediately from Redis.<br>
+ * But for typical store and forget or store and retrieve slightly later use
+ * cases,
  * Async methods will bring about quite a bit of throughput improvement.<br>
  * Operations support 2 data types:<br>
  * <ul>
@@ -121,36 +123,36 @@ import static org.eclipse.ecsp.cache.redis.RedisProperty.REDIS_KEY_NAMESPACE_DEL
  */
 @Repository
 public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
-    
+
     /** The Constant NUM_BATCH_RETRIES. */
     private static final int NUM_BATCH_RETRIES = 5;
-    
+
     /** The Constant MINUS_ONE_LONG. */
     public static final long MINUS_ONE_LONG = -1L;
-    
+
     /** The Constant REDIS_HEALTH_GUAGE. */
     public static final String REDIS_HEALTH_GUAGE = "REDIS_HEALTH_GUAGE";
-    
+
     /** The Constant REDIS_HEALTH_MONITOR. */
     public static final String REDIS_HEALTH_MONITOR = "REDIS_HEALTH_MONITOR";
-    
+
     /** The Constant LOGGER. */
     private static final IgniteLogger LOGGER = IgniteLoggerFactory.getLogger(IgniteCacheRedisImpl.class);
-    
+
     /** The scan limit. */
     @Value("${redis.scan.limit:100}")
     private int scanLimit;
-    
+
     /** The regex scan file name. */
     @Value("${redis.regex.scan.filename:scanregex.txt}")
     private String regexScanFileName;
-    
+
     /** The string codec. */
     private StringCodec stringCodec = new StringCodec();
-    
+
     /** The decoder. */
     private Decoder<Object> decoder;
-    
+
     /** The redisson client. */
     @Autowired
     private RedissonClient redissonClient;
@@ -160,15 +162,15 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     // parameter.
     @Value("${ignite.codec.class:}")
     private String igniteCodecClass;
-    
+
     /** The retry record id pattern. */
     @Value("${retry.record.id.pattern}")
     private String retryRecordIdPattern;
-    
+
     /** The object mapper. */
     @Autowired
     private ObjectMapper objectMapper;
-    
+
     /** The scan regex script. */
     private String scanRegexScript;
     /**
@@ -185,20 +187,20 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /** The current batch. */
     // batchSize entries; there can be more but not less. That is ok.
     private volatile RBatch currentBatch = null;
-    
+
     /** The batch count. */
     /*
      * used for tracking the current size of the batch and to trigger execution
      * when size equals batch size
      */
     private AtomicInteger batchCount = new AtomicInteger(0);
-    
+
     /** The last batch exec timestamp. */
     private AtomicLong lastBatchExecTimestamp = new AtomicLong(System.currentTimeMillis());
 
     /** The Constant MANDATORY_VALUE. */
     public static final String MANDATORY_VALUE = "value is mandatory";
-    
+
     /** The Constant MANDATORY_KEY. */
     public static final String MANDATORY_KEY = "key is mandatory";
 
@@ -221,7 +223,7 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
      * Instantiates a new ignite cache redis impl.
      */
     public IgniteCacheRedisImpl() {
-        //default constructor
+        // default constructor
     }
 
     /**
@@ -279,7 +281,7 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
      * @return the entity associated with the key
      */
     @Override
-    public <T extends IgniteEntity> T getEntity(String key) {
+    public <T> T getEntity(String key) {
         key = addNamespace(key, true);
         RBucket<T> bucket = redissonClient.getBucket(key);
         return bucket.get();
@@ -288,12 +290,12 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /**
      * Retrieves an entity from Redis based on the provided request.
      *
-     * @param <T> the type of the entity
+     * @param <T>     the type of the entity
      * @param request the request containing the key and namespace information
      * @return the entity associated with the key
      */
     @Override
-    public <T extends IgniteEntity> T getEntity(GetEntityRequest request) {
+    public <T> T getEntity(GetEntityRequest request) {
         request.withKey(addNamespace(request.getKey(), request.getNamespaceEnabled()));
         return (T) redissonClient.getBucket(request.getKey()).get();
     }
@@ -301,11 +303,11 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /**
      * Stores an entity in Redis based on the provided request.
      *
-     * @param <T> the type of the entity
+     * @param <T>        the type of the entity
      * @param putRequest the request containing the key, value, and other parameters
      */
     @Override
-    public <T extends IgniteEntity> void putEntity(PutEntityRequest<T> putRequest) {
+    public <T> void putEntity(PutEntityRequest<T> putRequest) {
         validate(putRequest);
         putRequest.withKey(addNamespace(putRequest.getKey(), putRequest.getNamespaceEnabled()));
         RBucket<T> bucket = redissonClient.getBucket(putRequest.getKey());
@@ -358,11 +360,11 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /**
      * Adds an entity to a scored sorted set in Redis.
      *
-     * @param <T> the type of the entity
+     * @param <T>     the type of the entity
      * @param request the request containing the key, value, and score
      */
     @Override
-    public <T extends IgniteEntity> void addEntityToScoredSortedSet(AddScoredEntityRequest<T> request) {
+    public <T> void addEntityToScoredSortedSet(AddScoredEntityRequest<T> request) {
         validate(request);
         request.withKey(addNamespace(request.getKey(), request.getNamespaceEnabled()));
         RScoredSortedSet<T> sset = redissonClient.getScoredSortedSet(request.getKey());
@@ -372,12 +374,12 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /**
      * Gets the entities from scored sorted set.
      *
-     * @param <T> the generic type
+     * @param <T>     the generic type
      * @param request the request
      * @return the entities from scored sorted set
      */
     @Override
-    public <T extends IgniteEntity> List<T> getEntitiesFromScoredSortedSet(GetScoredEntitiesRequest request) {
+    public <T> List<T> getEntitiesFromScoredSortedSet(GetScoredEntitiesRequest request) {
         validate(request);
         request.withKey(addNamespace(request.getKey(), request.getNamespaceEnabled()));
         RScoredSortedSet<T> sset = redissonClient.getScoredSortedSet(request.getKey());
@@ -427,12 +429,12 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /**
      * Asynchronously stores an entity in Redis based on the provided request.
      *
-     * @param <T> the type of the entity
+     * @param <T>        the type of the entity
      * @param putRequest the request containing the key, value, and other parameters
      * @return a Future representing the result of the asynchronous operation
      */
     @Override
-    public <T extends IgniteEntity> Future<String> putEntityAsync(PutEntityRequest<T> putRequest) {
+    public <T> Future<String> putEntityAsync(PutEntityRequest<T> putRequest) {
         validate(putRequest);
         putRequest.withKey(addNamespace(putRequest.getKey(), putRequest.getNamespaceEnabled()));
         CompletableFuture<String> f = new CompletableFuture<>();
@@ -478,12 +480,12 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /**
      * Adds the entity to a scored sorted set asynchronously.
      *
-     * @param <T> the generic type of the entity
+     * @param <T>     the generic type of the entity
      * @param request the request containing the entity and its score
      * @return a Future representing the result of the asynchronous operation
      */
     @Override
-    public <T extends IgniteEntity> Future<String> addEntityToScoredSortedSetAsync(AddScoredEntityRequest<T> request) {
+    public <T> Future<String> addEntityToScoredSortedSetAsync(AddScoredEntityRequest<T> request) {
         validate(request);
         request.withKey(addNamespace(request.getKey(), request.getNamespaceEnabled()));
         CompletableFuture<String> f = new CompletableFuture<>();
@@ -511,7 +513,8 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /**
      * Deletes the entry associated with the given key from Redis.
      *
-     * @param deleteRequest the delete request containing the key and namespace information
+     * @param deleteRequest the delete request containing the key and namespace
+     *                      information
      */
     @Override
     public void delete(DeleteEntryRequest deleteRequest) {
@@ -523,7 +526,8 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /**
      * Asynchronously deletes the entry associated with the given key from Redis.
      *
-     * @param deleteRequest the delete request containing the key and namespace information
+     * @param deleteRequest the delete request containing the key and namespace
+     *                      information
      * @return a Future representing the result of the asynchronous operation
      */
     @Override
@@ -550,15 +554,16 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     }
 
     /**
-     * This methods tries to scan redis keys with the regex provided and returns key value pairs.
+     * This methods tries to scan redis keys with the regex provided and returns key
+     * value pairs.
      *
-     * @param <T> the generic type
-     * @param keyRegex the key regex
+     * @param <T>              the generic type
+     * @param keyRegex         the key regex
      * @param namespaceEnabled the namespace enabled
      * @return the key value pairs for regex
      */
     @Override
-    public <T extends IgniteEntity> Map<String, T> getKeyValuePairsForRegex(
+    public <T> Map<String, T> getKeyValuePairsForRegex(
             String keyRegex, Optional<Boolean> namespaceEnabled) {
         Map<String, T> keyValuePairs = new HashMap<>();
         if ((namespaceEnabled.isPresent() && Boolean.TRUE.equals(namespaceEnabled.get()))
@@ -608,11 +613,11 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /**
      * Stores a map of entities in Redis based on the provided request.
      *
-     * @param <T> the type of the entities
+     * @param <T>        the type of the entities
      * @param mapRequest the request containing the key, value, and other parameters
      */
     @Override
-    public <T extends IgniteEntity> void putMapOfEntities(PutMapOfEntitiesRequest<T> mapRequest) {
+    public <T> void putMapOfEntities(PutMapOfEntitiesRequest<T> mapRequest) {
         validate(mapRequest);
         mapRequest.withKey(addNamespace(mapRequest.getKey(), mapRequest.getNamespaceEnabled()));
         String key = mapRequest.getKey();
@@ -626,12 +631,12 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /**
      * Retrieves a map of entities from Redis based on the provided request.
      *
-     * @param <T> the type of the entities
+     * @param <T>        the type of the entities
      * @param mapRequest the request containing the key and namespace information
      * @return the map of entities associated with the key
      */
     @Override
-    public <T extends IgniteEntity> Map<String, T> getMapOfEntities(GetMapOfEntitiesRequest mapRequest) {
+    public <T> Map<String, T> getMapOfEntities(GetMapOfEntitiesRequest mapRequest) {
         validate(mapRequest);
         mapRequest.withKey(addNamespace(mapRequest.getKey(), mapRequest.getNamespaceEnabled()));
         String key = mapRequest.getKey();
@@ -671,7 +676,7 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /**
      * Adds the namespace.
      *
-     * @param key the key
+     * @param key              the key
      * @param namespaceEnabled the namespace enabled
      * @return the string
      */
@@ -687,13 +692,16 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
 
     /**
      * Executes the batch operation consumer in a reliable way. <br>
-     * If a thread was performing a batch operation and another thread performed RBatch.execute() at the same time,
-     * then first thread will fail with IllegalStateException("Batch already has been executed").
-     * This method performs a retry for such scenarios. Also advances the batch state.
+     * If a thread was performing a batch operation and another thread performed
+     * RBatch.execute() at the same time,
+     * then first thread will fail with IllegalStateException("Batch already has
+     * been executed").
+     * This method performs a retry for such scenarios. Also advances the batch
+     * state.
      *
      * @param c the batch operation consumer
      * @throws RuntimeException
-     *         if NUM_BATCH_RETRIES exhausted, and it still fails
+     *                          if NUM_BATCH_RETRIES exhausted, and it still fails
      */
     private void performBatchOperation(Consumer<Void> c) {
         for (int i = 1; i <= NUM_BATCH_RETRIES; i++) {
@@ -747,9 +755,9 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /**
      * Completes the given CompletableFuture based on the success flag.
      *
-     * @param success     indicates if the operation was successful
-     * @param f           the CompletableFuture to complete
-     * @param mutationId  the mutation ID to complete the future with if successful
+     * @param success    indicates if the operation was successful
+     * @param f          the CompletableFuture to complete
+     * @param mutationId the mutation ID to complete the future with if successful
      */
     private void completeFuture(boolean success, CompletableFuture<String> f, final String mutationId) {
         if (success) {
@@ -782,7 +790,8 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
 
     /**
      * Initializes the `IgniteCacheRedisImpl` instance after construction.
-     * This method reads the scan regex script from the specified file and sets up the decoder.
+     * This method reads the scan regex script from the specified file and sets up
+     * the decoder.
      * It also starts the initial batch for Redis operations.
      *
      * @throws IgniteCacheException if there is an error reading the scan regex file
@@ -831,7 +840,8 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     /**
      * Starts a new batch for Redis operations.
      * This method initializes the `currentBatch` with a new instance of `RBatch`.
-     * It also resets the `batchCount` to 0 if it reaches the `batchSize` and updates the `lastBatchExecTimestamp`.
+     * It also resets the `batchCount` to 0 if it reaches the `batchSize` and
+     * updates the `lastBatchExecTimestamp`.
      */
     private void startBatch() {
         currentBatch = redissonClient.createBatch();
@@ -842,7 +852,8 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     }
 
     /**
-     * Validates the `PutMapOfEntitiesRequest` to ensure that the key and value are not null.
+     * Validates the `PutMapOfEntitiesRequest` to ensure that the key and value are
+     * not null.
      *
      * @param request the request containing the key and value to be validated
      * @throws NullPointerException if the key or value is null
@@ -865,7 +876,8 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     }
 
     /**
-     * Validates the `DeleteMapOfEntitiesRequest` to ensure that the key is not null.
+     * Validates the `DeleteMapOfEntitiesRequest` to ensure that the key is not
+     * null.
      *
      * @param request the request containing the key to be validated
      * @throws NullPointerException if the key is null
@@ -895,7 +907,8 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     }
 
     /**
-     * Validates the `AddScoredStringRequest` to ensure that the key and value are not null.
+     * Validates the `AddScoredStringRequest` to ensure that the key and value are
+     * not null.
      *
      * @param request the request containing the key and value to be validated
      * @throws NullPointerException if the key or value is null
@@ -916,7 +929,8 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     }
 
     /**
-     * Validates the `AddScoredEntityRequest` to ensure that the key and value are not null.
+     * Validates the `AddScoredEntityRequest` to ensure that the key and value are
+     * not null.
      *
      * @param request the request containing the key and value to be validated
      * @throws NullPointerException if the key or value is null
@@ -927,7 +941,8 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     }
 
     /**
-     * Validates the `GetScoredEntitiesRequest` to ensure that the key and value are not null.
+     * Validates the `GetScoredEntitiesRequest` to ensure that the key and value are
+     * not null.
      *
      * @param request the request containing the key and value to be validated
      * @throws NullPointerException if the key or value is null
@@ -937,7 +952,8 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     }
 
     /**
-     * Validates the `PutStringRequest` to ensure that the key and value are not null.
+     * Validates the `PutStringRequest` to ensure that the key and value are not
+     * null.
      *
      * @param request the request containing the key and value to be validated
      * @throws NullPointerException if the key or value is null
@@ -948,7 +964,8 @@ public class IgniteCacheRedisImpl implements IgniteCache, HealthMonitor {
     }
 
     /**
-     * Validates the `PutEntityRequest` to ensure that the key and value are not null.
+     * Validates the `PutEntityRequest` to ensure that the key and value are not
+     * null.
      *
      * @param request the request containing the key and value to be validated
      * @throws NullPointerException if the key or value is null

--- a/src/main/java/org/eclipse/ecsp/cache/redis/RedisConfig.java
+++ b/src/main/java/org/eclipse/ecsp/cache/redis/RedisConfig.java
@@ -474,7 +474,7 @@ public class RedisConfig {
         /**
          * Builds a RedissonClient using the provided properties.
          *
-         * @param props the properties to configure the RedissonClient
+         * @param props        the properties to configure the RedissonClient
          * @return the configured RedissonClient
          */
         public RedissonClient build(Map<String, String> props) {

--- a/src/test/java/org/eclipse/ecsp/cache/config/ItemToUserNameDeserializer.java
+++ b/src/test/java/org/eclipse/ecsp/cache/config/ItemToUserNameDeserializer.java
@@ -1,0 +1,22 @@
+package org.eclipse.ecsp.cache.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+
+/**
+ * Sample deserializer class.
+ */
+public class ItemToUserNameDeserializer extends JsonDeserializer<ItemToUserNameMapping> {
+
+    @Override
+    public ItemToUserNameMapping deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        final int number = 1234;
+        return new ItemToUserNameMapping(number, "pen", "user2");
+    }
+
+}

--- a/src/test/java/org/eclipse/ecsp/cache/config/ItemToUserNameMapping.java
+++ b/src/test/java/org/eclipse/ecsp/cache/config/ItemToUserNameMapping.java
@@ -1,0 +1,45 @@
+package org.eclipse.ecsp.cache.config;
+
+/**
+ * Sample class for testing the jackson mapper config.
+ */
+public class ItemToUserNameMapping {
+
+    private int id;
+    private String itemName;
+    private String userName;
+
+    /**
+     * Default constructor.
+     */
+    public ItemToUserNameMapping(int id, String itemName, String userName) {
+        this.id = id;
+        this.itemName = itemName;
+        this.userName = userName;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+}

--- a/src/test/java/org/eclipse/ecsp/cache/config/ItemToUserNameMappingSerializer.java
+++ b/src/test/java/org/eclipse/ecsp/cache/config/ItemToUserNameMappingSerializer.java
@@ -1,0 +1,25 @@
+package org.eclipse.ecsp.cache.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+/**
+ * sample serializer class for ItemToUserNameMapping.
+ */
+public class ItemToUserNameMappingSerializer extends JsonSerializer<ItemToUserNameMapping> {
+
+    @Override
+    public void serialize(ItemToUserNameMapping value, JsonGenerator jgen, SerializerProvider provider)
+            throws IOException, JsonProcessingException {
+
+        jgen.writeStartObject();
+        jgen.writeNumberField("id", value.getId());
+        jgen.writeStringField("itemName", value.getItemName());
+        jgen.writeStringField("owner", value.getUserName() + "-new");
+        jgen.writeEndObject();
+    }
+}

--- a/src/test/java/org/eclipse/ecsp/cache/config/JacksonMapperConfigInvalidDeserializationParamsTest.java
+++ b/src/test/java/org/eclipse/ecsp/cache/config/JacksonMapperConfigInvalidDeserializationParamsTest.java
@@ -1,0 +1,46 @@
+package org.eclipse.ecsp.cache.config;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Test case for mapping class to deserializer.
+ */
+
+@RunWith(Parameterized.class)
+public class JacksonMapperConfigInvalidDeserializationParamsTest {
+    String customDeserializerList;
+
+    public JacksonMapperConfigInvalidDeserializationParamsTest(String customDeserializerList) {
+        this.customDeserializerList = customDeserializerList;
+    }
+    
+    /**
+     * Helper method to pass each item in the array as an argument to the test method.
+     */
+    
+    @Parameterized.Parameters
+    public static Collection<?> customDeserializerList() {
+        return Arrays.asList(new Object[] { "org.eclipse.ecsp.cache.config.ItemToUserNameMapping:",
+                                            ":org.eclipse.ecsp.cache.config.ItemToUserNameDeserializer", 
+                                            "org.eclipse.ecsp.cache.config.ItemToUserNameMapping:"
+                                            + "org.eclipse.ecsp.cache.config.ItemToUserNameMappingSerializer" });
+    }
+
+    /**
+     * Negative scenario where proper pair is not given.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testInsufficientDeSerializationParams() {
+
+        JacksonMapperConfig config = new JacksonMapperConfig();
+        config.setCustomDeserializers(customDeserializerList);
+
+        // get the object mapper
+        config.jsonObjectMapper();
+    }
+}

--- a/src/test/java/org/eclipse/ecsp/cache/config/JacksonMapperConfigInvalidParamsSubTypeTest.java
+++ b/src/test/java/org/eclipse/ecsp/cache/config/JacksonMapperConfigInvalidParamsSubTypeTest.java
@@ -1,0 +1,45 @@
+package org.eclipse.ecsp.cache.config;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Test class.
+ */
+
+@RunWith(Parameterized.class)
+public class JacksonMapperConfigInvalidParamsSubTypeTest {
+
+    String customSubType;
+
+    public JacksonMapperConfigInvalidParamsSubTypeTest(String customSubType) {
+        this.customSubType = customSubType;
+    }
+
+    /**
+     * Helper method to pass each item in the array as an argument to the test method.
+     */
+    @Parameterized.Parameters
+    public static Collection<?> customSubTypeList() {
+        return Arrays.asList(new Object[] { "org.eclipse.ecsp.cache.config.ItemToUserNameMapping:",
+                                            ":newType",
+                                            "newType" });
+    }
+
+    /**
+     * Testing insufficient params in sub type.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testInsufficientParamsSubtype() {
+
+        JacksonMapperConfig config = new JacksonMapperConfig();
+        config.setCustomSubtypes(customSubType);
+
+        // get the object mapper
+        config.jsonObjectMapper();
+    }
+}

--- a/src/test/java/org/eclipse/ecsp/cache/config/JacksonMapperConfigInvalidSerializationParamsTest.java
+++ b/src/test/java/org/eclipse/ecsp/cache/config/JacksonMapperConfigInvalidSerializationParamsTest.java
@@ -1,0 +1,44 @@
+package org.eclipse.ecsp.cache.config;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Test case for mapping class to serializer.
+ */
+
+@RunWith(Parameterized.class)
+public class JacksonMapperConfigInvalidSerializationParamsTest {
+    String customSerializerList;
+
+    public JacksonMapperConfigInvalidSerializationParamsTest(String customSerializerList) {
+        this.customSerializerList = customSerializerList;
+    }
+    
+    /**
+     * Helper method to pass each item in the array as an argument to the test method.
+     */
+    @Parameterized.Parameters
+    public static Collection<?> customSerializerList() {
+        return Arrays.asList(new Object[] { "org.eclipse.ecsp.cache.config.ItemToUserNameMapping:",
+                                            ":org.eclipse.ecsp.cache.config.ItemToUserNameMappingSerializer" });
+    }
+
+    /**
+     * Negative scenario where proper pair is not given.
+     */
+    
+    @Test(expected = IllegalStateException.class)
+    public void testInsufficientSerializationParams() {
+
+        JacksonMapperConfig config = new JacksonMapperConfig();
+        config.setCustomSerializers(customSerializerList);
+
+        // get the object mapper
+        config.jsonObjectMapper();
+    }
+}

--- a/src/test/java/org/eclipse/ecsp/cache/config/JacksonMapperConfigTest.java
+++ b/src/test/java/org/eclipse/ecsp/cache/config/JacksonMapperConfigTest.java
@@ -1,0 +1,104 @@
+package org.eclipse.ecsp.cache.config;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Testing Jackson Mapper config class.
+ */
+public class JacksonMapperConfigTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JacksonMapperConfigTest.class);
+
+    /**
+     * Test to add custom serializer to the mapper.
+     *
+     * @throws JsonProcessingException  JsonProcessingException
+     */
+    @Test
+    public void testCustomSerializer() throws JsonProcessingException {
+        JacksonMapperConfig config = new JacksonMapperConfig();
+        // adding the custom serializer for Sample class
+        String customSerializerList =
+                "org.eclipse.ecsp.cache.config."
+                        + "ItemToUserNameMapping:org.eclipse.ecsp.cache.config.ItemToUserNameMappingSerializer";
+        config.setCustomSerializers(customSerializerList);
+
+        // get the object mapper
+        ObjectMapper mapper = config.jsonObjectMapper();
+
+        ItemToUserNameMapping s = new ItemToUserNameMapping(1, "soap", "user1");
+        String actualString = mapper.writeValueAsString(s);
+        // as per the serializer, "-new will be added to the user1 string and
+        // the field name will be owner
+        LOGGER.info("Modified sample string:{}", actualString);
+
+        String expectedString = "{\"id\":1,\"itemName\":\"soap\",\"owner\":\"user1-new\"}";
+        Assert.assertEquals(expectedString, actualString);
+
+    }
+
+    /**
+     * Test to add custom deserializer.
+     *
+     * @throws IOException         I/O Exception
+     * @throws JsonMappingException JsonMappingException
+     * @throws JsonParseException  JsonParseException
+     */
+    @Test
+    public void testCustomDeserializer() throws JsonParseException, JsonMappingException, IOException {
+        JacksonMapperConfig config = new JacksonMapperConfig();
+        String customDeserializerList = "org.eclipse.ecsp.cache.config"
+                + ".ItemToUserNameMapping:org.eclipse.ecsp.cache.config.ItemToUserNameDeserializer";
+        config.setCustomDeserializers(customDeserializerList);
+
+        // get the object mapper
+        ObjectMapper mapper = config.jsonObjectMapper();
+        String itemString = "{\"id\":1,\"itemName\":\"soap\",\"userName\":\"user1-new\"}";
+        ItemToUserNameMapping obj = mapper.readValue(itemString, ItemToUserNameMapping.class);
+
+        // in the deserializer class, we have changed the value of itemnNam to
+        // pen and userName to "user2"
+        Assert.assertNotNull(obj);
+
+        Assert.assertEquals("Item names must be same", "pen", obj.getItemName());
+        Assert.assertEquals("User names must be same", "user2", obj.getUserName());
+    }
+    
+    /**
+     * Negative test cases in which we have added deserializer class in case
+     * serialization is expected.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testImproperClassProvidedInSerializer() {
+
+        JacksonMapperConfig config = new JacksonMapperConfig();
+        String customSerializerList = "org.eclipse.ecsp.cache.config.ItemToUserNameMapping:"
+                + "org.eclipse.ecsp.cache.config.ItemToUserNameDeserializer";
+        config.setCustomSerializers(customSerializerList);
+
+        // get the object mapper
+        config.jsonObjectMapper();
+    }
+    
+    @Test(expected = IllegalStateException.class)
+    public void testInsufficientParamsSubtype() {
+        Properties p = new Properties();
+        JacksonMapperConfig config = new JacksonMapperConfig(p);
+        String customSubtypes = "newType";
+        config.setCustomSubtypes(customSubtypes);
+
+        // get the object mapper
+        config.jsonObjectMapper();
+    }
+
+}

--- a/src/test/java/org/eclipse/ecsp/cache/redis/EmbeddedRedisSentinelServer.java
+++ b/src/test/java/org/eclipse/ecsp/cache/redis/EmbeddedRedisSentinelServer.java
@@ -46,7 +46,6 @@ import redis.embedded.RedisSentinel;
 import redis.embedded.RedisServer;
 import redis.embedded.util.Architecture;
 import redis.embedded.util.OS;
-
 import java.util.Arrays;
 
 /**

--- a/src/test/java/org/eclipse/ecsp/cache/redis/EmbeddedRedisServerTest.java
+++ b/src/test/java/org/eclipse/ecsp/cache/redis/EmbeddedRedisServerTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 import static org.eclipse.ecsp.cache.redis.RedisConstants.TEN_THOUSAND;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
+
 /**
  * Test case for the {@link EmbeddedRedisServer} class.
  */

--- a/src/test/java/org/eclipse/ecsp/cache/redis/IgniteCacheRedisImplIntegrationTest.java
+++ b/src/test/java/org/eclipse/ecsp/cache/redis/IgniteCacheRedisImplIntegrationTest.java
@@ -48,10 +48,7 @@ import org.eclipse.ecsp.cache.IgniteCache;
 import org.eclipse.ecsp.cache.PutEntityRequest;
 import org.eclipse.ecsp.cache.PutMapOfEntitiesRequest;
 import org.eclipse.ecsp.cache.PutStringRequest;
-import org.eclipse.ecsp.cache.redis.IgniteCacheRedisImpl;
-import org.eclipse.ecsp.cache.redis.RedisConfig;
 import org.eclipse.ecsp.domain.Version;
-import org.eclipse.ecsp.entities.IgniteEntity;
 import org.eclipse.ecsp.utils.logger.IgniteLogger;
 import org.eclipse.ecsp.utils.logger.IgniteLoggerFactory;
 import org.junit.Assert;
@@ -103,7 +100,8 @@ import static org.eclipse.ecsp.cache.redis.RedisConstants.TWO_HUNDRED;
 public class IgniteCacheRedisImplIntegrationTest {
 
     /** The Constant LOGGER. */
-    private static final IgniteLogger LOGGER = IgniteLoggerFactory.getLogger(IgniteCacheRedisImplIntegrationTest.class);
+    private static final IgniteLogger LOGGER
+        = IgniteLoggerFactory.getLogger(IgniteCacheRedisImplIntegrationTest.class);
 
     /** The redis. */
     @ClassRule
@@ -147,7 +145,7 @@ public class IgniteCacheRedisImplIntegrationTest {
         igniteCache.delete(new DeleteEntryRequest().withKey("hello"));
         Assert.assertNull(igniteCache.getString("hello"));
     }
-    
+
     /**
      * Test delete entryrequest with namespace enabled.
      */
@@ -335,7 +333,8 @@ public class IgniteCacheRedisImplIntegrationTest {
      * @throws ExecutionException the execution exception
      */
     @Test
-    public void testAddScoredSortedEntityBatchedWithNamespaceEnabled() throws InterruptedException, ExecutionException {
+    public void testAddScoredSortedEntityBatchedWithNamespaceEnabled()
+        throws InterruptedException, ExecutionException {
         ((IgniteCacheRedisImpl) igniteCache).setBatchSize((int) FIVE.getValue());
         List<Future<String>> futures = new ArrayList<>();
         // test 2 batches at least
@@ -399,7 +398,7 @@ public class IgniteCacheRedisImplIntegrationTest {
         igniteCache.putEntity(req1);
         igniteCache.putEntity(req2);
         igniteCache.putEntity(req3);
-        Map<String, IgniteEntity> kv;
+        Map<String, IgniteCacheIntegTestEntity> kv;
         kv = igniteCache.getKeyValuePairsForRegex("TESTKEY*", Optional.of(Boolean.TRUE));
         Assert.assertEquals(TWO.getValue(), kv.size());
         Assert.assertTrue(kv.containsKey("namespace:TESTKEY1"));
@@ -443,7 +442,7 @@ public class IgniteCacheRedisImplIntegrationTest {
         igniteCache.putEntity(req1);
         igniteCache.putEntity(req2);
         igniteCache.putEntity(req3);
-        Map<String, IgniteEntity> kv = null;
+        Map<String, IgniteCacheIntegTestEntity> kv = null;
         kv = igniteCache.getKeyValuePairsForRegex("TESTKEY*", Optional.of(Boolean.FALSE));
         Assert.assertEquals(TWO.getValue(), kv.size());
         Assert.assertTrue(kv.containsKey("TESTKEY1"));
@@ -477,7 +476,7 @@ public class IgniteCacheRedisImplIntegrationTest {
         igniteCache.putEntity(req1);
         igniteCache.putEntity(req2);
         igniteCache.putEntity(req3);
-        Map<String, IgniteEntity> kv = null;
+        Map<String, IgniteCacheIntegTestEntity> kv = null;
         kv = igniteCache.getKeyValuePairsForRegex("INCORRECT*", Optional.of(Boolean.TRUE));
         Assert.assertEquals(0, kv.size());
     }
@@ -495,7 +494,7 @@ public class IgniteCacheRedisImplIntegrationTest {
         req2.withKey("TESTKEY2").withValue(value2).withNamespaceEnabled(false);
         igniteCache.putEntity(req1);
         igniteCache.putEntity(req2);
-        Map<String, IgniteEntity> kv = null;
+        Map<String, IgniteCacheIntegTestEntity> kv = null;
         kv = igniteCache.getKeyValuePairsForRegex("TESTKEY2", Optional.of(Boolean.FALSE));
         Assert.assertEquals(1, kv.size());
     }
@@ -712,7 +711,8 @@ public class IgniteCacheRedisImplIntegrationTest {
      * @throws ExecutionException the execution exception
      */
     @Test
-    public void testAddScoredSortedEntityBatchedWithNullMutationId() throws InterruptedException, ExecutionException {
+    public void testAddScoredSortedEntityBatchedWithNullMutationId()
+        throws InterruptedException, ExecutionException {
         ((IgniteCacheRedisImpl) igniteCache).setBatchSize(FIVE.getValue());
         List<Future<String>> futures = new ArrayList<>();
         // test 2 batches at least
@@ -822,14 +822,14 @@ public class IgniteCacheRedisImplIntegrationTest {
     /**
      * Test for addStringToScoredSortedSetAsync with namespace enabled.
      */
-    public static class IgniteCacheIntegTestEntity implements IgniteEntity, Comparable<IgniteCacheIntegTestEntity> {
+    public static class IgniteCacheIntegTestEntity implements Comparable<IgniteCacheIntegTestEntity> {
 
         /** The id. */
         private String id;
-        
+
         /** The value. */
         private String value;
-        
+
         /** The order. */
         private int order;
 
@@ -863,7 +863,6 @@ public class IgniteCacheRedisImplIntegrationTest {
          *
          * @return the schema version
          */
-        @Override
         public Version getSchemaVersion() {
             return schemaVersion;
         }
@@ -873,7 +872,6 @@ public class IgniteCacheRedisImplIntegrationTest {
          *
          * @param arg0 the new schema version
          */
-        @Override
         public void setSchemaVersion(Version arg0) {
             this.schemaVersion = arg0;
         }

--- a/src/test/java/org/eclipse/ecsp/cache/redis/IgniteCacheRedisImplUnitTest.java
+++ b/src/test/java/org/eclipse/ecsp/cache/redis/IgniteCacheRedisImplUnitTest.java
@@ -36,6 +36,7 @@
 
 package org.eclipse.ecsp.cache.redis;
 
+import dev.morphia.annotations.Entity;
 import org.eclipse.ecsp.cache.AddScoredEntityRequest;
 import org.eclipse.ecsp.cache.AddScoredStringRequest;
 import org.eclipse.ecsp.cache.DeleteEntryRequest;
@@ -48,9 +49,7 @@ import org.eclipse.ecsp.cache.GetStringRequest;
 import org.eclipse.ecsp.cache.PutEntityRequest;
 import org.eclipse.ecsp.cache.PutMapOfEntitiesRequest;
 import org.eclipse.ecsp.cache.PutStringRequest;
-import org.eclipse.ecsp.cache.redis.IgniteCacheRedisImpl;
 import org.eclipse.ecsp.domain.Version;
-import org.eclipse.ecsp.entities.IgniteEntity;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -63,7 +62,6 @@ import org.redisson.api.RScoredSortedSetAsync;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.protocol.ScoredEntry;
 import org.redisson.misc.CompletableFutureWrapper;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -74,6 +72,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.eclipse.ecsp.cache.redis.RedisConstants.FIVE;
 
+
 /**
  * Unit test class for IgniteCacheRedisImpl.
  */
@@ -81,7 +80,7 @@ public class IgniteCacheRedisImplUnitTest {
 
     /** The Constant THOUSAND_LONG. */
     private static final long THOUSAND_LONG = 1000L;
-    
+
     /** The Constant TWO_DOUBLE. */
     private static final double TWO_DOUBLE = 2.0D;
 
@@ -131,7 +130,7 @@ public class IgniteCacheRedisImplUnitTest {
      * Test delete entry async request with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test
     public void testDeleteEntryAsyncRequestWithNamespaceDisabled() throws InterruptedException, ExecutionException {
@@ -243,11 +242,11 @@ public class IgniteCacheRedisImplUnitTest {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
         RedissonClient redisson = Mockito.mock(RedissonClient.class);
         RBucket<Object> rbucket = (RBucket<Object>) Mockito.mock(RBucket.class);
-        IgniteCacheTestEntity entity = new IgniteCacheTestEntity();
+        PlatformCacheTestEntity entity = new PlatformCacheTestEntity();
         Mockito.when(rbucket.get()).thenReturn(entity);
         Mockito.when(redisson.getBucket("hello")).thenReturn(rbucket);
         redisCache.setRedissonClient(redisson);
-        IgniteCacheTestEntity entityRead = redisCache.getEntity("hello");
+        PlatformCacheTestEntity entityRead = redisCache.getEntity("hello");
         Assert.assertEquals(entity, entityRead);
         Mockito.verify(rbucket).get();
     }
@@ -260,11 +259,11 @@ public class IgniteCacheRedisImplUnitTest {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
         RedissonClient redisson = Mockito.mock(RedissonClient.class);
         RBucket<Object> rbucket = (RBucket<Object>) Mockito.mock(RBucket.class);
-        IgniteCacheTestEntity entity = new IgniteCacheTestEntity();
+        PlatformCacheTestEntity entity = new PlatformCacheTestEntity();
         Mockito.when(rbucket.get()).thenReturn(entity);
         Mockito.when(redisson.getBucket("hello")).thenReturn(rbucket);
         redisCache.setRedissonClient(redisson);
-        IgniteCacheTestEntity entityRead = redisCache.getEntity(
+        PlatformCacheTestEntity entityRead = redisCache.getEntity(
                 new GetEntityRequest()
                         .withKey("hello")
                         .withNamespaceEnabled(false));
@@ -290,8 +289,9 @@ public class IgniteCacheRedisImplUnitTest {
         RBucket<Object> rbucket = (RBucket<Object>) Mockito.mock(RBucket.class);
         Mockito.when(redisson.getBucket("hello")).thenReturn(rbucket);
         redisCache.setRedissonClient(redisson);
-        IgniteCacheTestEntity entity = new IgniteCacheTestEntity();
-        PutEntityRequest<IgniteCacheTestEntity> req = new PutEntityRequest<IgniteCacheTestEntity>();
+        PlatformCacheTestEntity entity = new PlatformCacheTestEntity();
+        PutEntityRequest<PlatformCacheTestEntity> req
+            = new PutEntityRequest<PlatformCacheTestEntity>();
         req.withKey("hello").withValue(entity).withNamespaceEnabled(false);
         redisCache.putEntity(req);
         Mockito.verify(rbucket).set(entity);
@@ -303,7 +303,7 @@ public class IgniteCacheRedisImplUnitTest {
     @Test(expected = NullPointerException.class)
     public void testPutEntityWithNullKeyValueWithNamespaceDisabled() {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
-        redisCache.putEntity(new PutEntityRequest<IgniteCacheTestEntity>());
+        redisCache.putEntity(new PutEntityRequest<PlatformCacheTestEntity>());
     }
 
     /**
@@ -316,8 +316,9 @@ public class IgniteCacheRedisImplUnitTest {
         RBucket<Object> rbucket = (RBucket<Object>) Mockito.mock(RBucket.class);
         Mockito.when(redisson.getBucket("hello")).thenReturn(rbucket);
         redisCache.setRedissonClient(redisson);
-        IgniteCacheTestEntity entity = new IgniteCacheTestEntity();
-        PutEntityRequest<IgniteCacheTestEntity> req = new PutEntityRequest<IgniteCacheTestEntity>();
+        PlatformCacheTestEntity entity = new PlatformCacheTestEntity();
+        PutEntityRequest<PlatformCacheTestEntity> req
+            = new PutEntityRequest<PlatformCacheTestEntity>();
         req.withKey("hello").withValue(entity).withNamespaceEnabled(false);
         req.withTtlMs(THOUSAND_LONG);
         redisCache.putEntity(req);
@@ -334,9 +335,10 @@ public class IgniteCacheRedisImplUnitTest {
         RBucket<Object> rbucket = (RBucket<Object>) Mockito.mock(RBucket.class);
         Mockito.when(redisson.getBucket("hello")).thenReturn(rbucket);
         redisCache.setRedissonClient(redisson);
-        IgniteCacheTestEntity newEntity = new IgniteCacheTestEntity();
-        IgniteCacheTestEntity oldEntity = new IgniteCacheTestEntity();
-        PutEntityRequest<IgniteCacheTestEntity> req = new PutEntityRequest<IgniteCacheTestEntity>();
+        PlatformCacheTestEntity newEntity = new PlatformCacheTestEntity();
+        PlatformCacheTestEntity oldEntity = new PlatformCacheTestEntity();
+        PutEntityRequest<PlatformCacheTestEntity> req
+            = new PutEntityRequest<PlatformCacheTestEntity>();
         req.withKey("hello").withValue(newEntity).withNamespaceEnabled(false);
         req.ifCurrentMatches(oldEntity);
         redisCache.putEntity(req);
@@ -384,7 +386,8 @@ public class IgniteCacheRedisImplUnitTest {
     }
 
     /**
-     * Test add string to scored sorted set with null key value with namespace disabled.
+     * Test add string to scored sorted set with null key value with namespace
+     * disabled.
      */
     @Test(expected = NullPointerException.class)
     public void testAddStringToScoredSortedSetWithNullKeyValueWithNamespaceDisabled() {
@@ -422,7 +425,8 @@ public class IgniteCacheRedisImplUnitTest {
     }
 
     /**
-     * Test get strings from scored sorted set with null key with namespace disabled.
+     * Test get strings from scored sorted set with null key with namespace
+     * disabled.
      */
     @Test(expected = NullPointerException.class)
     public void testGetStringsFromScoredSortedSetWithNullKeyWithNamespaceDisabled() {
@@ -472,10 +476,12 @@ public class IgniteCacheRedisImplUnitTest {
         RScoredSortedSet<Object> rsss = (RScoredSortedSet<Object>) Mockito.mock(RScoredSortedSet.class);
         Mockito.when(redisson.getScoredSortedSet("entities")).thenReturn(rsss);
         redisCache.setRedissonClient(redisson);
-        IgniteCacheTestEntity entity = new IgniteCacheTestEntity();
+        PlatformCacheTestEntity entity = new PlatformCacheTestEntity();
         redisCache.addEntityToScoredSortedSet(
-                new AddScoredEntityRequest<IgniteCacheTestEntity>().withKey("entities").withScore(1D).withValue(entity)
-                        .withNamespaceEnabled(false));
+                new AddScoredEntityRequest<PlatformCacheTestEntity>()
+                .withKey("entities")
+                .withScore(1D).withValue(entity)
+                .withNamespaceEnabled(false));
         Mockito.verify(rsss).add(1D, entity);
     }
 
@@ -485,9 +491,9 @@ public class IgniteCacheRedisImplUnitTest {
     @Test(expected = NullPointerException.class)
     public void testAddEntityToScoredSortedSetWithNullKeyWithNamespaceDisabled() {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
-        IgniteCacheTestEntity entity = new IgniteCacheTestEntity();
+        PlatformCacheTestEntity entity = new PlatformCacheTestEntity();
         redisCache.addEntityToScoredSortedSet(
-                new AddScoredEntityRequest<IgniteCacheTestEntity>()
+                new AddScoredEntityRequest<PlatformCacheTestEntity>()
                         .withScore(1D)
                         .withValue(entity)
                         .withNamespaceEnabled(false));
@@ -500,20 +506,21 @@ public class IgniteCacheRedisImplUnitTest {
     public void testAddEntityToScoredSortedSetWithNullValueWithNamespaceDisabled() {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
         redisCache.addEntityToScoredSortedSet(
-                new AddScoredEntityRequest<IgniteCacheTestEntity>()
+                new AddScoredEntityRequest<PlatformCacheTestEntity>()
                         .withKey("entities")
                         .withScore(1D)
                         .withNamespaceEnabled(false));
     }
 
     /**
-     * Test add entity to scored sorted set with null key value with namespace disabled.
+     * Test add entity to scored sorted set with null key value with namespace
+     * disabled.
      */
     @Test(expected = NullPointerException.class)
     public void testAddEntityToScoredSortedSetWithNullKeyValueWithNamespaceDisabled() {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
         redisCache.addEntityToScoredSortedSet(
-                new AddScoredEntityRequest<IgniteCacheTestEntity>()
+                new AddScoredEntityRequest<PlatformCacheTestEntity>()
                         .withScore(1D)
                         .withNamespaceEnabled(false));
     }
@@ -527,16 +534,16 @@ public class IgniteCacheRedisImplUnitTest {
         RScoredSortedSet<Object> rsss = (RScoredSortedSet<Object>) Mockito.mock(RScoredSortedSet.class);
         Mockito.when(redisson.getScoredSortedSet("entities")).thenReturn(rsss);
         List<ScoredEntry<Object>> entities = new ArrayList<>();
-        IgniteEntity entity1 = new IgniteCacheTestEntity();
-        IgniteEntity entity2 = new IgniteCacheTestEntity();
+        PlatformCacheTestEntity entity1 = new PlatformCacheTestEntity();
+        PlatformCacheTestEntity entity2 = new PlatformCacheTestEntity();
         entities.add(new ScoredEntry<Object>(1D, entity1));
         entities.add(new ScoredEntry<Object>(TWO_DOUBLE, entity2));
         Mockito.when(rsss.entryRange(1, FIVE.getValue())).thenReturn(entities);
-        List<IgniteEntity> expectedEntities = Arrays.asList(entity1, entity2);
+        List<PlatformCacheTestEntity> expectedEntities = Arrays.asList(entity1, entity2);
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
         redisCache.setRedissonClient(redisson);
 
-        List<IgniteCacheTestEntity> actualEntities = redisCache
+        List<PlatformCacheTestEntity> actualEntities = redisCache
                 .getEntitiesFromScoredSortedSet(
                         new GetScoredEntitiesRequest()
                                 .withKey("entities")
@@ -548,7 +555,8 @@ public class IgniteCacheRedisImplUnitTest {
     }
 
     /**
-     * Test get entities from scored sorted set with null key with namespace disabled.
+     * Test get entities from scored sorted set with null key with namespace
+     * disabled.
      */
     @Test(expected = NullPointerException.class)
     public void testGetEntitiesFromScoredSortedSetWithNullKeyWithNamespaceDisabled() {
@@ -571,16 +579,16 @@ public class IgniteCacheRedisImplUnitTest {
         RScoredSortedSet<Object> rsss = (RScoredSortedSet<Object>) Mockito.mock(RScoredSortedSet.class);
         Mockito.when(redisson.getScoredSortedSet("entities")).thenReturn(rsss);
         List<ScoredEntry<Object>> entities = new ArrayList<>();
-        IgniteEntity entity1 = new IgniteCacheTestEntity();
-        IgniteEntity entity2 = new IgniteCacheTestEntity();
+        PlatformCacheTestEntity entity1 = new PlatformCacheTestEntity();
+        PlatformCacheTestEntity entity2 = new PlatformCacheTestEntity();
         entities.add(new ScoredEntry<Object>(1D, entity2));
         entities.add(new ScoredEntry<Object>(TWO_DOUBLE, entity1));
         Mockito.when(rsss.entryRangeReversed(1, FIVE.getValue())).thenReturn(entities);
-        List<IgniteEntity> expectedEntities = Arrays.asList(entity2, entity1);
+        List<PlatformCacheTestEntity> expectedEntities = Arrays.asList(entity2, entity1);
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
         redisCache.setRedissonClient(redisson);
 
-        List<IgniteCacheTestEntity> actualEntities = redisCache.getEntitiesFromScoredSortedSet(
+        List<PlatformCacheTestEntity> actualEntities = redisCache.getEntitiesFromScoredSortedSet(
                 new GetScoredEntitiesRequest().withKey("entities")
                         .withStartIndex(1)
                         .withEndIndex(FIVE.getValue())
@@ -594,7 +602,7 @@ public class IgniteCacheRedisImplUnitTest {
      * Test put string key value async with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test
     public void testPutStringKeyValueAsyncWithNamespaceDisabled() throws InterruptedException, ExecutionException {
@@ -619,12 +627,11 @@ public class IgniteCacheRedisImplUnitTest {
      * Test put string key value async with null key with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test(expected = NullPointerException.class)
     public void testPutStringKeyValueAsyncWithNullKeyWithNamespaceDisabled()
-            throws
-            InterruptedException, ExecutionException {
+            throws InterruptedException, ExecutionException {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
         Future<String> ret = redisCache.putStringAsync(
                 new PutStringRequest()
@@ -637,7 +644,7 @@ public class IgniteCacheRedisImplUnitTest {
      * Test put string key value async with null value with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test(expected = NullPointerException.class)
     public void testPutStringKeyValueAsyncWithNullValueWithNamespaceDisabled()
@@ -651,10 +658,11 @@ public class IgniteCacheRedisImplUnitTest {
     }
 
     /**
-     * Test put string key value async with null mutation id with namespace disabled.
+     * Test put string key value async with null mutation id with namespace
+     * disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test
     public void testPutStringKeyValueAsyncWithNullMutationIdWithNamespaceDisabled()
@@ -680,7 +688,7 @@ public class IgniteCacheRedisImplUnitTest {
      * Test put string key value with ttl async with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test
     public void testPutStringKeyValueWithTtlAsyncWithNamespaceDisabled()
@@ -708,7 +716,7 @@ public class IgniteCacheRedisImplUnitTest {
      * Test put string key value if async with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test
     public void testPutStringKeyValueIfAsyncWithNamespaceDisabled()
@@ -734,19 +742,19 @@ public class IgniteCacheRedisImplUnitTest {
      * Test put entity async with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test
     public void testPutEntityAsyncWithNamespaceDisabled()
             throws InterruptedException, ExecutionException {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
-        IgniteCacheTestEntity entity = new IgniteCacheTestEntity();
+        PlatformCacheTestEntity entity = new PlatformCacheTestEntity();
         RBatch rbatch = Mockito.mock(RBatch.class);
         redisCache.setRBatch(rbatch);
         RBucketAsync<Object> rbucket = (RBucketAsync<Object>) Mockito.mock(RBucketAsync.class);
         Mockito.when(rbatch.getBucket("hello")).thenReturn(rbucket);
         Mockito.when(rbucket.setAsync(entity)).thenReturn(new CompletableFutureWrapper<Void>((Void) null));
-        PutEntityRequest<IgniteCacheTestEntity> req = new PutEntityRequest<>();
+        PutEntityRequest<PlatformCacheTestEntity> req = new PutEntityRequest<>();
         req.withKey("hello").withValue(entity).withMutationId("mut001").withNamespaceEnabled(false);
         Future<String> ret = redisCache.putEntityAsync(req);
         Assert.assertTrue(ret.isDone());
@@ -758,14 +766,15 @@ public class IgniteCacheRedisImplUnitTest {
      * Test put entity async with null key with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test(expected = NullPointerException.class)
     public void testPutEntityAsyncWithNullKeyWithNamespaceDisabled()
             throws InterruptedException, ExecutionException {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
-        IgniteCacheTestEntity entity = new IgniteCacheTestEntity();
-        PutEntityRequest<IgniteCacheTestEntity> req = new PutEntityRequest<IgniteCacheTestEntity>();
+        PlatformCacheTestEntity entity = new PlatformCacheTestEntity();
+        PutEntityRequest<PlatformCacheTestEntity> req
+            = new PutEntityRequest<PlatformCacheTestEntity>();
         req.withValue(entity).withMutationId("mut001").withNamespaceEnabled(false);
         redisCache.putEntityAsync(req);
     }
@@ -774,14 +783,16 @@ public class IgniteCacheRedisImplUnitTest {
      * Test put entity async with null value with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test(expected = NullPointerException.class)
     public void testPutEntityAsyncWithNullValueWithNamespaceDisabled()
             throws InterruptedException, ExecutionException {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
-        PutEntityRequest<IgniteCacheTestEntity> req = new PutEntityRequest<IgniteCacheTestEntity>();
-        req.withKey("hello").withMutationId("mut001").withNamespaceEnabled(false);
+        PutEntityRequest<PlatformCacheTestEntity> req
+            = new PutEntityRequest<PlatformCacheTestEntity>();
+        req.withKey("hello").withMutationId("mut001")
+            .withNamespaceEnabled(false);
         redisCache.putEntityAsync(req);
     }
 
@@ -789,26 +800,26 @@ public class IgniteCacheRedisImplUnitTest {
      * Test put entity async with null key value with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test(expected = NullPointerException.class)
     public void testPutEntityAsyncWithNullKeyValueWithNamespaceDisabled()
             throws InterruptedException, ExecutionException {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
         redisCache
-                .putEntityAsync(new PutEntityRequest<IgniteCacheTestEntity>());
+                .putEntityAsync(new PutEntityRequest<PlatformCacheTestEntity>());
     }
 
     /**
      * Test put entity with ttl async with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test
     public void testPutEntityWithTtlAsyncWithNamespaceDisabled() throws InterruptedException, ExecutionException {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
-        IgniteCacheTestEntity entity = new IgniteCacheTestEntity();
+        PlatformCacheTestEntity entity = new PlatformCacheTestEntity();
         RBatch rbatch = Mockito.mock(RBatch.class);
         redisCache.setRBatch(rbatch);
         RBucketAsync<Object> rbucket = (RBucketAsync<Object>) Mockito.mock(RBucketAsync.class);
@@ -816,7 +827,7 @@ public class IgniteCacheRedisImplUnitTest {
         Mockito.when(
                 rbucket.setAsync(entity, THOUSAND_LONG, TimeUnit.MILLISECONDS))
                 .thenReturn(new CompletableFutureWrapper<Void>((Void) null));
-        PutEntityRequest<IgniteCacheTestEntity> req = new PutEntityRequest<>();
+        PutEntityRequest<PlatformCacheTestEntity> req = new PutEntityRequest<>();
         req.withKey("hello").withValue(entity).withMutationId("mut001").withNamespaceEnabled(false);
         req.withTtlMs(THOUSAND_LONG);
         Future<String> ret = redisCache.putEntityAsync(req);
@@ -829,14 +840,14 @@ public class IgniteCacheRedisImplUnitTest {
      * Test put entity if async with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test
     public void testPutEntityIfAsyncWithNamespaceDisabled()
             throws InterruptedException, ExecutionException {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
-        IgniteCacheTestEntity newEntity = new IgniteCacheTestEntity();
-        IgniteCacheTestEntity oldEntity = new IgniteCacheTestEntity();
+        PlatformCacheTestEntity newEntity = new PlatformCacheTestEntity();
+        PlatformCacheTestEntity oldEntity = new PlatformCacheTestEntity();
         RBatch rbatch = Mockito.mock(RBatch.class);
         redisCache.setRBatch(rbatch);
         RBucketAsync<Object> rbucket = (RBucketAsync<Object>) Mockito.mock(RBucketAsync.class);
@@ -844,7 +855,7 @@ public class IgniteCacheRedisImplUnitTest {
         Mockito.when(
                 rbucket.compareAndSetAsync(oldEntity, newEntity))
                 .thenReturn(new CompletableFutureWrapper(true));
-        PutEntityRequest<IgniteCacheTestEntity> req = new PutEntityRequest<>();
+        PutEntityRequest<PlatformCacheTestEntity> req = new PutEntityRequest<>();
         req.withKey("hello").withValue(newEntity).withMutationId("mut001").withNamespaceEnabled(false);
         req.ifCurrentMatches(oldEntity);
         Future<String> ret = redisCache
@@ -858,7 +869,7 @@ public class IgniteCacheRedisImplUnitTest {
      * Test add string to scored sorted set async with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test
     public void testAddStringToScoredSortedSetAsyncWithNamespaceDisabled()
@@ -885,7 +896,7 @@ public class IgniteCacheRedisImplUnitTest {
      * Test add entity to scored sorted set async with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test
     public void testAddEntityToScoredSortedSetAsyncWithNamespaceDisabled()
@@ -897,10 +908,10 @@ public class IgniteCacheRedisImplUnitTest {
         RScoredSortedSetAsync<Object> rsss = (RScoredSortedSetAsync<Object>) Mockito.mock(RScoredSortedSetAsync.class);
         Mockito.when(rbatch.getScoredSortedSet("entities")).thenReturn(rsss);
         RFuture<Boolean> rfuture = (RFuture<Boolean>) Mockito.mock(RFuture.class);
-        IgniteCacheTestEntity entity = new IgniteCacheTestEntity();
+        PlatformCacheTestEntity entity = new PlatformCacheTestEntity();
         Mockito.when(rsss.addAsync(1D, entity)).thenReturn(rfuture);
         Future<String> ret = redisCache.addEntityToScoredSortedSetAsync(
-                new AddScoredEntityRequest<IgniteCacheTestEntity>()
+                new AddScoredEntityRequest<PlatformCacheTestEntity>()
                         .withKey("entities")
                         .withScore(1D)
                         .withValue(entity)
@@ -914,11 +925,11 @@ public class IgniteCacheRedisImplUnitTest {
      * Test async completed exceptionally with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test
     public void testAsyncCompletedExceptionallyWithNamespaceDisabled() throws InterruptedException, ExecutionException {
-        IgniteCacheTestEntity entity = new IgniteCacheTestEntity();
+        PlatformCacheTestEntity entity = new PlatformCacheTestEntity();
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
         redisCache.setBatchSize(FIVE.getValue());
         RBatch rbatch = Mockito.mock(RBatch.class);
@@ -927,7 +938,7 @@ public class IgniteCacheRedisImplUnitTest {
         Mockito.when(rsss.addAsync(1D, entity)).thenReturn(new CompletableFutureWrapper(false));
         redisCache.setRBatch(rbatch);
         Future<String> ret = redisCache.addEntityToScoredSortedSetAsync(
-                new AddScoredEntityRequest<IgniteCacheTestEntity>()
+                new AddScoredEntityRequest<PlatformCacheTestEntity>()
                         .withKey("entities")
                         .withScore(1D)
                         .withValue(entity)
@@ -949,14 +960,13 @@ public class IgniteCacheRedisImplUnitTest {
      * Test async batch already executed with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test
     public void testAsyncBatchAlreadyExecutedWithNamespaceDisabled()
-            throws
-            InterruptedException,
+            throws InterruptedException,
             ExecutionException {
-        IgniteCacheTestEntity entity = new IgniteCacheTestEntity();
+        PlatformCacheTestEntity entity = new PlatformCacheTestEntity();
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
         redisCache.setBatchSize(FIVE.getValue());
         RBatch rbatch = Mockito.mock(RBatch.class);
@@ -967,7 +977,7 @@ public class IgniteCacheRedisImplUnitTest {
         redisCache.setRBatch(rbatch);
         try {
             Future<String> ret = redisCache.addEntityToScoredSortedSetAsync(
-                    new AddScoredEntityRequest<IgniteCacheTestEntity>()
+                    new AddScoredEntityRequest<PlatformCacheTestEntity>()
                             .withKey("entities")
                             .withScore(1D)
                             .withValue(entity)
@@ -985,12 +995,12 @@ public class IgniteCacheRedisImplUnitTest {
      * Test async batch unexpected illegal state exception with namespace disabled.
      *
      * @throws InterruptedException the interrupted exception
-     * @throws ExecutionException the execution exception
+     * @throws ExecutionException   the execution exception
      */
     @Test
     public void testAsyncBatchUnexpectedIllegalStateExceptionWithNamespaceDisabled()
             throws InterruptedException, ExecutionException {
-        IgniteCacheTestEntity entity = new IgniteCacheTestEntity();
+        PlatformCacheTestEntity entity = new PlatformCacheTestEntity();
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
         redisCache.setBatchSize(FIVE.getValue());
         RBatch rbatch = Mockito.mock(RBatch.class);
@@ -1001,7 +1011,7 @@ public class IgniteCacheRedisImplUnitTest {
         redisCache.setRBatch(rbatch);
         try {
             Future<String> ret = redisCache.addEntityToScoredSortedSetAsync(
-                    new AddScoredEntityRequest<IgniteCacheTestEntity>()
+                    new AddScoredEntityRequest<PlatformCacheTestEntity>()
                             .withKey("entities")
                             .withScore(1D)
                             .withValue(entity)
@@ -1059,7 +1069,7 @@ public class IgniteCacheRedisImplUnitTest {
     @Test(expected = NullPointerException.class)
     public void testPutMapWithNullKey() {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
-        redisCache.putMapOfEntities(new PutMapOfEntitiesRequest<IgniteCacheTestEntity>());
+        redisCache.putMapOfEntities(new PutMapOfEntitiesRequest<PlatformCacheTestEntity>());
     }
 
     /**
@@ -1068,7 +1078,7 @@ public class IgniteCacheRedisImplUnitTest {
     @Test(expected = NullPointerException.class)
     public void testPutMapWithNullValueWithNamespaceDisabled() {
         IgniteCacheRedisImpl redisCache = new IgniteCacheRedisImpl();
-        PutMapOfEntitiesRequest req = new PutMapOfEntitiesRequest<IgniteCacheTestEntity>();
+        PutMapOfEntitiesRequest req = new PutMapOfEntitiesRequest<PlatformCacheTestEntity>();
         req.withKey("abc").withNamespaceEnabled(false);
         redisCache.putMapOfEntities(req);
     }
@@ -1085,7 +1095,8 @@ public class IgniteCacheRedisImplUnitTest {
     /**
      * Test entity for testing.
      */
-    public class IgniteCacheTestEntity implements IgniteEntity {
+    @Entity
+    public class PlatformCacheTestEntity {
 
         /** The schema version. */
         private Version schemaVersion;
@@ -1095,7 +1106,6 @@ public class IgniteCacheRedisImplUnitTest {
          *
          * @return the schema version
          */
-        @Override
         public Version getSchemaVersion() {
             return schemaVersion;
         }
@@ -1105,7 +1115,6 @@ public class IgniteCacheRedisImplUnitTest {
          *
          * @param arg0 the new schema version
          */
-        @Override
         public void setSchemaVersion(Version arg0) {
             this.schemaVersion = arg0;
         }

--- a/src/test/java/org/eclipse/ecsp/cache/redis/RedissonClientCreationTest.java
+++ b/src/test/java/org/eclipse/ecsp/cache/redis/RedissonClientCreationTest.java
@@ -26,7 +26,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.redisson.api.RedissonClient;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -54,7 +53,6 @@ public class RedissonClientCreationTest {
      */
     @Before
     public void setup() {
-
         LOGGER.info("Initializing redisson client...");
         Map<String, String> props = getPropertiesMap();
         RedisConfig redisConfig = new RedisConfig();


### PR DESCRIPTION
Please refer to our [contributing docs](./CONTRIBUTING.md) for any questions on submitting a pull request.
Issues are required for both bug fixes and features.

Resolves #ISSUE_NUMBER 
<!-- Link to related issue(s) -->

----
### Describe behaviour before the change
<!-- Please describe the current behavior that you are modifying. -->
The CacheEnabler is not generic enough to work with entities that are dependent on Ignite Entities. It is also dependent on Ignite Transformers that some projects does not need to have as a dependency while using the CacheEnabler library.

* 

### Describe behaviour after the change
<!-- Please describe the behavior or changes that are being added by this PR. -->
The change generifies the CacheEnabler to be not dependent on Ignite Entities and Ignite Transformers. Any class can be used as an entity for Redis, not only classes that extends the IgniteEntity.
* 

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----

